### PR TITLE
Update README to mention Discord secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ There are a few steps to the setup but it should hopefully be pretty straightfor
 1. Clone the repo
 2. Edit `src/config.ts` - here you can set the status URL, name of the webhook, avatar and publish channel
 3. Put your IDs in `wrangler.toml`
-4. Add Discord webhook and Discord Bot token with `wrangler secret put DISCORD_WEBHOOK` and `wrangler secret put DISCORD_TOKEN`
+4. Add Discord webhook with `wrangler secret put DISCORD_WEBHOOK`
+4b. (optional) If you want publishing, you'll also need to add a Discord bot token with `wrangler secret put DISCORD_TOKEN`
 5. Run `npm run publish` :)
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ There are a few steps to the setup but it should hopefully be pretty straightfor
 1. Clone the repo
 2. Edit `src/config.ts` - here you can set the status URL, name of the webhook, avatar and publish channel
 3. Put your IDs in `wrangler.toml`
-4. Run `npm run publish` :)
+4. Add Discord webhook and Discord Bot token with `wrangler secret put DISCORD_WEBHOOK` and `wrangler secret put DISCORD_TOKEN`
+5. Run `npm run publish` :)
 
 ## Example
 ### New Incident

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ There are a few steps to the setup but it should hopefully be pretty straightfor
 1. Clone the repo
 2. Edit `src/config.ts` - here you can set the status URL, name of the webhook, avatar and publish channel
 3. Put your IDs in `wrangler.toml`
-4. Add Discord webhook with `wrangler secret put DISCORD_WEBHOOK`
-4b. (optional) If you want publishing, you'll also need to add a Discord bot token with `wrangler secret put DISCORD_TOKEN`
+4. Add Discord webhook with `wrangler secret put DISCORD_WEBHOOK` \
+  4b. (optional) If you want publishing, you'll also need to add a Discord bot token with `wrangler secret put DISCORD_TOKEN`
 5. Run `npm run publish` :)
 
 ## Example


### PR DESCRIPTION
Without the secrets the Worker will either do nothing or error silently, and I couldn't find them mentioned elsewhere.

Not 100% sure if there's some better way to show these two commands, and maybe we could mention the token is only required if publishing is needed? But this should do for a simple mention rather than leaving it unsaid and letting the user figure it out.

Changes are very welcome!