### PR TITLE
Show component group names, truncate description/impact to fit

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -8,18 +8,13 @@ export async function sendToDiscord(incident: Incident, components: Component[],
 
   const fields: { name: string, value: string, inline?: boolean }[] = [];
 
-  let description = getDescription(incident);
   const impact = getImpact(incident, components);
-
   if (impact !== null) {
     fields.push({
       name: 'Impacted Services',
       value: impact,
       inline: false,
     });
-
-    // Hack: We want a bit of spacing between the statuses and the impact field.
-    description += '\n** **\n** **';
   }
 
   const messageId = incident.messageId;
@@ -32,7 +27,7 @@ export async function sendToDiscord(incident: Incident, components: Component[],
       type: 'rich',
       title: `${incident.name}`,
       url: getIncidentLink(incident),
-      description,
+      description: getDescription(incident, impact !== null),
       timestamp: incident.started_at,
       color: getStatusColor(incident.status),
       fields,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,7 +1,7 @@
 import { getDescription, getImpact, getIncidentLink, getStatusColor } from './utils';
 import Config from './config';
 
-export async function sendToDiscord(incident: Incident, env: Env): Promise<string | null> {
+export async function sendToDiscord(incident: Incident, components: Component[], env: Env): Promise<string | null> {
   if (Config.EXCLUDED_STATUSES.includes(incident.status)) {
     return null;
   }
@@ -9,7 +9,7 @@ export async function sendToDiscord(incident: Incident, env: Env): Promise<strin
   const fields: { name: string, value: string, inline?: boolean }[] = [];
 
   let description = getDescription(incident);
-  const impact = getImpact(incident);
+  const impact = getImpact(incident, components);
 
   if (impact !== null) {
     fields.push({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,6 +15,11 @@ interface IncidentResponse {
   incidents: Incident[];
 }
 
+interface ComponentResponse {
+  page: Page;
+  components: Component[];
+}
+
 interface Page {
   id: string;
   name: string;
@@ -66,7 +71,7 @@ interface ComponentUpdate {
   new_status: ComponentStatus;
 }
 
-interface Component {
+interface CoreComponent {
   id: string;
   name: string;
   status: ComponentStatus;
@@ -75,12 +80,26 @@ interface Component {
   position: number;
   description: string | null;
   showcase: boolean;
-  start_date: string;
-  group_id: string;
+  start_date: string | null;
+  group_id: string | null;
   page_id: string;
   group: boolean;
   only_show_if_degraded: boolean;
 }
+
+interface ComponentIndividual extends CoreComponent {
+  start_date: string;
+  group: false;
+}
+
+interface ComponentGroup extends CoreComponent {
+  start_date: null;
+  group_id: null;
+  group: true;
+  components: string[];
+}
+
+type Component = ComponentIndividual | ComponentGroup;
 
 interface DiscordResponse {
   id: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,7 @@ export function getDescription(incident: Incident, spacing: boolean) {
   const updates = sorted.map(update => {
     const time = new Date(update.created_at);
     const ms = Math.floor(time.getTime() / 1000);
-    return `**${pascalCase(update.status)}** - <t:${ms}:F> (<t:${ms}:R>)\n${update.body}`;
+    return `**${pascalCase(update.status)}** - <t:${ms}:F> (<t:${ms}:R>)\n${update.body.replace(/\n([\u200b\u200c]*\n)+/ug, '\n\n').trim()}`;
   });
 
   // Hack: We want a bit of spacing between the statuses and the impact field

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,15 +18,15 @@ export function getStatusColor(status: IncidentStatus) {
 }
 
 function getTruncated(items: string[], joiner: string, suffix: string | ((removed: string[]) => string), length: number) {
-  if (items.join(joiner).length <= length) return items.join(joiner);
-
   const truncated = [ ...items ];
+  let computedTruncated = truncated.join(joiner);
+  if (computedTruncated.length <= length) return computedTruncated;
+
   const removed: string[] = [];
-  
   const getSuffix = () => typeof(suffix) === 'function' ? suffix(removed) : suffix;
   let computedSuffix = getSuffix();
 
-  while (truncated.join(joiner).length + computedSuffix.length > length) {
+  while (computedTruncated.length + computedSuffix.length > length) {
     if (truncated.length === 1) {
       const suffixNewline = computedSuffix.startsWith('\n');
       truncated[0] = truncated[0].slice(0, length - computedSuffix.length - (suffixNewline ? 1 : 0));
@@ -35,10 +35,11 @@ function getTruncated(items: string[], joiner: string, suffix: string | ((remove
       removed.unshift(truncated.pop()!);
     }
 
+    computedTruncated = truncated.join(joiner);
     computedSuffix = getSuffix();
   }
 
-  return truncated.join(joiner) + computedSuffix;
+  return computedTruncated + computedSuffix;
 }
 
 export function getDescription(incident: Incident, spacing: boolean) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,12 +31,18 @@ export function getDescription(incident: Incident) {
   return description.trim();
 }
 
-export function getImpact(incident: Incident): string | null {
-  if (incident.components.length === 0) {
-    return null;
-  }
+export function getImpact(incident: Incident, components: Component[]): string | null {
+  if (incident.components.length === 0) return null;
 
-  return incident.components.map(component => `${component.name} - ${pascalCase(component.status)}`).join('\n');
+  const groups = components.reduce((acc, component) => component.group
+    ? { ...acc, [component.id]: component }
+    : acc, {} as { [id: string]: Component });
+
+  return incident.components.map(component => [
+    component.group_id && groups[component.group_id].name,
+    component.name,
+    pascalCase(component.status),
+  ].filter(Boolean).join(' - ')).join('\n');
 }
 
 export function pascalCase(str: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,8 @@ function getTruncated(items: string[], joiner: string, suffix: string | ((remove
   while (truncated.join(joiner).length + computedSuffix.length > length) {
     if (truncated.length === 1) {
       const suffixNewline = computedSuffix.startsWith('\n');
-      truncated[0] = truncated[0].slice(0, length - computedSuffix.length - (suffixNewline ? 3 : 0));
-      truncated[0] = truncated[0].slice(0, truncated[0].lastIndexOf(' ')) + (suffixNewline ? ' ...' : ' ');
+      truncated[0] = truncated[0].slice(0, length - computedSuffix.length - (suffixNewline ? 1 : 0));
+      truncated[0] = truncated[0].slice(0, truncated[0].lastIndexOf(' ')) + (suffixNewline ? ' …' : ' ');
     } else {
       removed.unshift(truncated.pop()!);
     }
@@ -57,7 +57,7 @@ export function getDescription(incident: Incident, spacing: boolean) {
 
   // Hack: We want a bit of spacing between the statuses and the impact field
   const spacer = spacing ? '\n** **\n** **' : '';
-  const suffix = (removed: string[]) => `\n\n... [and ${removed.length.toLocaleString()} more update${removed.length === 1 ? '' : 's'}](${getIncidentLink(incident)})`;
+  const suffix = (removed: string[]) => `\n\n… [and ${removed.length.toLocaleString()} more update${removed.length === 1 ? '' : 's'}](${getIncidentLink(incident)})`;
   return getTruncated(updates, '\n\n', suffix, 4096 - spacer.length) + spacer;
 }
 
@@ -74,7 +74,7 @@ export function getImpact(incident: Incident, components: Component[]): string |
     pascalCase(component.status),
   ].filter(Boolean).join(' - '));
 
-  const suffix = (removed: string[]) => `\n\n... [and ${removed.length.toLocaleString()} more service${removed.length === 1 ? '' : 's'}](${getIncidentLink(incident)})`;
+  const suffix = (removed: string[]) => `\n\n… [and ${removed.length.toLocaleString()} more service${removed.length === 1 ? '' : 's'}](${getIncidentLink(incident)})`;
   return getTruncated(impacted, '\n', suffix, 1024);
 }
 


### PR DESCRIPTION
~~This is currently based on #10, hence a draft.~~

👋 Following on from my previous PR, this does two more things to improve the usability of the updates in Discord:

- If a component is part of a component group on the status page, the group name will be shown in the impact list
- If the description or impact list is too long to fit in Discord, they will be smartly truncated (one item at a time) to fit, with the incident link being added to view more (closes #12)

I've also snuck in two QoL things: ensuring that updates are sorted by date (I think status page already does this, but no harm in ensuring it), and trimming out excessive line breaks from the body of each update